### PR TITLE
Fixed memory leak on windows for Demodulator.

### DIFF
--- a/decoder/xritDecoder.vcxproj
+++ b/decoder/xritDecoder.vcxproj
@@ -129,7 +129,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;MAJOR_VERSION=1;MINOR_VERSION=0;MAINT_VERSION=1;GIT_SHA1=Microsoft Visual C++ Compiler</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;MAJOR_VERSION=1;MINOR_VERSION=0;MAINT_VERSION=2;GIT_SHA1=Microsoft Visual C++ Compiler</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
@@ -144,7 +144,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;MAJOR_VERSION=1;MINOR_VERSION=0;MAINT_VERSION=1;GIT_SHA1=Microsoft Visual C++ Compiler</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;MAJOR_VERSION=1;MINOR_VERSION=0;MAINT_VERSION=2;GIT_SHA1=Microsoft Visual C++ Compiler</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
@@ -161,7 +161,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;MAJOR_VERSION=1;MINOR_VERSION=0;MAINT_VERSION=1;GIT_SHA1=Microsoft Visual C++ Compiler</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;MAJOR_VERSION=1;MINOR_VERSION=0;MAINT_VERSION=2;GIT_SHA1=Microsoft Visual C++ Compiler</PreprocessorDefinitions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
@@ -180,7 +180,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;MAJOR_VERSION=1;MINOR_VERSION=0;MAINT_VERSION=1;GIT_SHA1=Microsoft Visual C++ Compiler</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;MAJOR_VERSION=1;MINOR_VERSION=0;MAINT_VERSION=2;GIT_SHA1=Microsoft Visual C++ Compiler</PreprocessorDefinitions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>

--- a/demodulator/src/SymbolManager.cpp
+++ b/demodulator/src/SymbolManager.cpp
@@ -98,6 +98,12 @@ void SymbolManager::add(float *data, int length) {
 
 void SymbolManager::add(std::complex<float> *data, int length) {
 	dataMutex.lock();
+
+    if (dataQueue.size() >= SM_MAX_SYMBOL_BUFFER) {
+        std::cerr << "SymbolManager Buffer is full!!! Dropping samples." << std::endl;
+        return;
+    }
+
 	for (int i = 0; i < length; i++) {
 		dataQueue.push(data[i].imag()); // M&M Outputs the data in imaginary
 	}

--- a/demodulator/src/SymbolManager.h
+++ b/demodulator/src/SymbolManager.h
@@ -18,7 +18,8 @@
 namespace OpenSatelliteProject {
 
 // Number of symbols
-#define SM_SOCKET_BUFFER_SIZE 1024
+#define SM_SOCKET_BUFFER_SIZE 16384
+#define SM_MAX_SYMBOL_BUFFER (1024 * 1024)
 
 class SymbolManager {
 private:

--- a/demodulator/src/demodulator.cpp
+++ b/demodulator/src/demodulator.cpp
@@ -308,13 +308,11 @@ int main(int argc, char **argv) {
 				std::cerr << "Failed to open Airspy Device: " << e.reason() << std::endl;
 				exit(1);
 			}
-			bool isMini = false;
 			bool sampleRateSet = false;
 
 			std::vector<uint32_t> sampleRates = device->GetAvailableSampleRates();
 			for (uint32_t asSR : sampleRates) {
 				if (asSR == sampleRate) {
-					isMini = true;
 					device->SetSampleRate(sampleRate);
 					sampleRateSet = true;
 					break;
@@ -326,9 +324,7 @@ int main(int argc, char **argv) {
 				return 1;
 			}
 
-			std::cout << "Airspy " << (isMini ? "Mini " : "R2 ")
-					<< "detected. Sample rate set to " << device->GetSampleRate()
-					<< std::endl;
+			std::cout << "Airspy sample rate set to " << device->GetSampleRate() << std::endl;
 
 		} else if (parser[CFG_DEVICE_TYPE] == "cfile") {
 			if (!parser.hasKey(CFG_FILENAME)) {

--- a/demodulator/xritDemodulator.vcxproj
+++ b/demodulator/xritDemodulator.vcxproj
@@ -101,7 +101,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;MAJOR_VERSION=1;MINOR_VERSION=0;MAINT_VERSION=1;GIT_SHA1=Microsoft Visual C++ Compiler</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;MAJOR_VERSION=1;MINOR_VERSION=0;MAINT_VERSION=2;GIT_SHA1=Microsoft Visual C++ Compiler</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
@@ -116,7 +116,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;MAJOR_VERSION=1;MINOR_VERSION=0;MAINT_VERSION=1;GIT_SHA1=Microsoft Visual C++ Compiler</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;MAJOR_VERSION=1;MINOR_VERSION=0;MAINT_VERSION=2;GIT_SHA1=Microsoft Visual C++ Compiler</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
@@ -133,7 +133,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;MAJOR_VERSION=1;MINOR_VERSION=0;MAINT_VERSION=1;GIT_SHA1=Microsoft Visual C++ Compiler</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;MAJOR_VERSION=1;MINOR_VERSION=0;MAINT_VERSION=2;GIT_SHA1=Microsoft Visual C++ Compiler</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -151,7 +151,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;MAJOR_VERSION=1;MINOR_VERSION=0;MAINT_VERSION=1;GIT_SHA1=Microsoft Visual C++ Compiler</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;MAJOR_VERSION=1;MINOR_VERSION=0;MAINT_VERSION=2;GIT_SHA1=Microsoft Visual C++ Compiler</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
*	Increase the SymbolManager Socket Buffer from 1024 to 16384 seens to fix the memory leak on windows.
*	Imposed a hard limit on how much Symbol Manager Queue can grow.